### PR TITLE
スマホサイトのviewport設定

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -5,6 +5,8 @@
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
     <%= stylesheet_pack_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
     <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>
   </head>


### PR DESCRIPTION
## 関連するイシュー
なし

## 変更内容
- スマホの場合のviewportを設定することで、レイアウトが崩れないようにする

## スクリーンショット(あれば)
| Before | After |
| -------| ------ |
| <img width="1221" alt="image" src="https://github.com/mayu-tateno/techpit-matching-app/assets/87419889/cf27a690-5ee2-4bf9-a0b6-ab93189feedc"> | <img width="1271" alt="image" src="https://github.com/mayu-tateno/techpit-matching-app/assets/87419889/95586627-fc41-45d9-92a4-b6ac018e4efe"> |

## 確認方法

- [x] `localhost:3000` にアクセスし、ディベロッパツールでスマホ表示に切り替えて確認

## 参考にした記事・備考


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved website's responsiveness on mobile devices with new viewport settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->