### PR TITLE
usersテーブルにカラムを追加

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,9 @@
 class ApplicationController < ActionController::Base
+  before_action :configure_permitted_parameters, if: :devise_controller?
+
+  protected
+
+  def configure_permitted_parameters
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:name, :gender])
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,4 +3,6 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
+  
+  validates :name, presence: true
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,4 +5,6 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable
   
   validates :name, presence: true
+
+  enum gender: { man: 0, woman: 1 }
 end

--- a/db/migrate/20240227140400_add_name_and_gender_to_user.rb
+++ b/db/migrate/20240227140400_add_name_and_gender_to_user.rb
@@ -1,0 +1,6 @@
+class AddNameAndGenderToUser < ActiveRecord::Migration[6.0]
+  def change
+    add_column :users, :name, :string, null: false
+    add_column :users, :gender, :integer, null: false, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_02_22_161351) do
+ActiveRecord::Schema.define(version: 2024_02_27_140400) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -23,6 +23,8 @@ ActiveRecord::Schema.define(version: 2024_02_22_161351) do
     t.datetime "remember_created_at"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "name", null: false
+    t.integer "gender", default: 0, null: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end


### PR DESCRIPTION
## 関連するイシュー
なし

## 変更内容
- usersテーブルに`name`, `gender`のカラムを追加
- ` gender`のenumを追加
- deviceによって追加したusersテーブルにカラムを追加したので、ストロングパラメータの設定を追加

## スクリーンショット(あれば)
| Before | After |
| -------| ------ |
|  |  |

なし

## 確認方法

- [x] 追加したカラムの情報もDBに保存できる

## 参考にした記事・備考


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced sign-up process to include `name` and `gender` as part of user registration.
	- Introduced validation for the `name` field to ensure it is not left blank and added gender options.

- **Database Changes**
	- Added `name` and `gender` columns to the `users` table to support new registration fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->